### PR TITLE
Hard coded android (linux) line ending in generated license files.

### DIFF
--- a/rigol_vendor_bin.c
+++ b/rigol_vendor_bin.c
@@ -455,7 +455,7 @@ generate_single_option( char *family, char *model, char *opt, int new )
     strcat( fname, ".lic" );
     if( ( f = fopen( fname, "w" ) ) != NULL )
     {
-      fprintf( f, "%s@%s\0x0A", opt, res );
+      fprintf( f, "%s@%s\x0A", opt, res );
       fclose( f );
       printf( "%s ", opt );
     }

--- a/rigol_vendor_bin.c
+++ b/rigol_vendor_bin.c
@@ -455,7 +455,7 @@ generate_single_option( char *family, char *model, char *opt, int new )
     strcat( fname, ".lic" );
     if( ( f = fopen( fname, "w" ) ) != NULL )
     {
-      fprintf( f, "%s@%s\n", opt, res );
+      fprintf( f, "%s@%s\0x0A", opt, res );
       fclose( f );
       printf( "%s ", opt );
     }


### PR DESCRIPTION
While compiled for Windows target system current implementation of generate_single_option() adds /n characters in generated license files as for Windows /0x10/0xA (CR LF) instead of 0x0A .

The destination system for license files is android(linux) so line endings in generated license files should be hard coded for that system. 
It causes sparrow.apk boot looping if license file is generated on Windows (with Windows line ending) and then transfered to scope.