### PR TITLE
add required chmod, reboot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ to transfer the ARM64 executable to your scope then run it:
  - adb -s IP:55555 push generate_all_options /rigol/data
  - adb -s IP:55555 shell
  - cd /rigol/data
+ - chmod +x generate_all_options
  - ./generate_all_options
-This will create all the option.lic files which will be installed at next reboot.
+ - reboot
+
+This will create all the option.lic files, which will take effect after the reboot.
 
 Included is a native utility program 'nv-mem' which allows you
 to read/write/compare the FRAM content and also covers the functionality of


### PR DESCRIPTION
users will receive "permission denied" when trying to run the binary after adb pushing it, as it hasn't been marked executable yet. Not a big deal for any linux user, but could get newbies stuck. Also added a reboot command, so you can finish the whole process from the same adb session.